### PR TITLE
Open ExportVars, add ImportVars, add SetGroupBool

### DIFF
--- a/GameSettings.lua
+++ b/GameSettings.lua
@@ -234,6 +234,18 @@ function GameSettings.ToggleGroup(path)
 	end
 end
 
+-- set all booleans in the group to val
+function GameSettings.SetGroupBool(path, val)
+	local group = Game.GetSettingsSystem():GetGroup(path)
+	local vars = group:GetVars(false)
+
+	for _, var in ipairs(vars) do
+		if module.isBoolType(var:GetType()) then
+			var:SetValue(val)
+		end
+	end
+end
+
 function GameSettings.Options(setting)
 	local path, name = module.parsePath(setting)
 
@@ -280,6 +292,10 @@ end
 
 function GameSettings.Save()
 	GetSingleton('inkMenuScenario'):GetSystemRequestsHandler():RequestSaveUserSettings()
+end
+
+function GameSettings.ExportVars(isPreGame, group, output)
+        return module.exportVars(isPreGame, group, output)
 end
 
 function GameSettings.Export(isPreGame)
@@ -355,6 +371,13 @@ function GameSettings.ImportFrom(importPath)
 
 	if importChunk then
 		GameSettings.Import(importChunk())
+	end
+end
+
+-- For importing the result of ExportVars directly
+function GameSettings.ImportVars(settings)
+	for _, var in ipairs(settings) do
+		GameSettings.Set(var.path, var.value)
 	end
 end
 


### PR DESCRIPTION
A few modifications to allow exporting and importing variables without converting the result into a string or file.

Plus additional helper function to set all group boolean values.

This can be useful for storing settings temporarily in memory when mod needs it.

Example is a simple HUD toggle mod that saves HUD settings state, then turns them all off and then restores them.

Note: The change to `exportVars` is simply making it public and moving the code down for it.